### PR TITLE
Upgrade dependencies

### DIFF
--- a/dip/pom.xml
+++ b/dip/pom.xml
@@ -10,6 +10,4 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dip</artifactId>
-
-
 </project>

--- a/dip/src/test/java/com/codurance/dip/BirthdayGreeterShould.java
+++ b/dip/src/test/java/com/codurance/dip/BirthdayGreeterShould.java
@@ -1,10 +1,10 @@
 package com.codurance.dip;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -15,7 +15,7 @@ import static com.codurance.dip.EmployeeBuilder.anEmployee;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BirthdayGreeterShould {
     private static final int CURRENT_MONTH = 7;
     private static final int CURRENT_DAY_OF_MONTH = 9;
@@ -37,16 +37,18 @@ public class BirthdayGreeterShould {
         System.setOut(new PrintStream(consoleContent));
         given(clock.monthDay()).willReturn(TODAY);
         Employee employee = anEmployee().build();
-        given(employeeRepository.findEmployeesBornOn(MonthDay.of(CURRENT_MONTH, CURRENT_DAY_OF_MONTH))).willReturn(Collections.singletonList(employee));
+        given(employeeRepository.findEmployeesBornOn(MonthDay.of(
+                CURRENT_MONTH,
+                CURRENT_DAY_OF_MONTH
+        ))).willReturn(Collections.singletonList(employee));
 
         birthdayGreeter.sendGreetings();
 
         String actual = consoleContent.toString();
         assertThat(actual)
-                .isEqualTo("To:" + employee.getEmail() + ", Subject: Happy birthday!, Message: Happy birthday, dear " + employee.getFirstName()+"!");
+                .isEqualTo("To:" + employee.getEmail() + ", Subject: Happy birthday!, Message: Happy birthday, dear " + employee.getFirstName() + "!");
 
     }
-
 
 
 }

--- a/isp/pom.xml
+++ b/isp/pom.xml
@@ -10,6 +10,4 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>isp</artifactId>
-
-
 </project>

--- a/lsp/pom.xml
+++ b/lsp/pom.xml
@@ -10,6 +10,4 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>lsp</artifactId>
-
-
 </project>

--- a/lsp/src/test/java/com/codurance/lsp/FillingStationShould.java
+++ b/lsp/src/test/java/com/codurance/lsp/FillingStationShould.java
@@ -1,6 +1,6 @@
 package com.codurance.lsp;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;

--- a/lsp/src/test/java/com/codurance/lsp/VehicleShould.java
+++ b/lsp/src/test/java/com/codurance/lsp/VehicleShould.java
@@ -1,6 +1,6 @@
 package com.codurance.lsp;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/ocp/pom.xml
+++ b/ocp/pom.xml
@@ -10,6 +10,4 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ocp</artifactId>
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,53 +16,75 @@
         <module>dip</module>
     </modules>
 
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.11.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>5.11.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-bom</artifactId>
+                <version>3.26.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Should.java</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-
-    <dependencies>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.8.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- Only required to run tests in a version of IntelliJ IDEA that bundles an older version -->
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <version>1.0.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.0.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>4.12.3</version>
-            <scope>test</scope>
-        </dependency>
-
-    </dependencies>
-
 </project>

--- a/srp/pom.xml
+++ b/srp/pom.xml
@@ -10,18 +10,4 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>srp</artifactId>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-
 </project>

--- a/srp/src/test/java/com/codurance/srp/AccountServiceShould.java
+++ b/srp/src/test/java/com/codurance/srp/AccountServiceShould.java
@@ -1,12 +1,11 @@
 package com.codurance.srp;
 
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -15,18 +14,19 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AccountServiceShould {
 
     private static final int POSITIVE_AMOUNT = 100;
     private static final int NEGATIVE_AMOUNT = -POSITIVE_AMOUNT;
     private static final LocalDate TODAY = LocalDate.of(2017, 9, 6);
     private static final List<Transaction> TRANSACTIONS = Arrays.asList(
-        new Transaction(LocalDate.of(2014, 4, 1), 1000),
-        new Transaction(LocalDate.of(2014, 4, 2), -100),
-        new Transaction(LocalDate.of(2014, 4, 10), 500)
+            new Transaction(LocalDate.of(2014, 4, 1), 1000),
+            new Transaction(LocalDate.of(2014, 4, 2), -100),
+            new Transaction(LocalDate.of(2014, 4, 10), 500)
     );
 
     @Mock
@@ -40,10 +40,10 @@ public class AccountServiceShould {
 
     private AccountService accountService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         accountService = new AccountService(transactionRepository, clock, console);
-        given(clock.today()).willReturn(TODAY);
+        lenient().doReturn(TODAY).when(clock).today();
     }
 
 
@@ -77,5 +77,3 @@ public class AccountServiceShould {
         inOrder.verify(console).printLine("01/04/2014 | 1000.00 | 1000.00");
     }
 }
-
-


### PR DESCRIPTION
This pull request updates the project to modern version of the language and dependencies:
- Java 21
- Junit Jupiter and Mockito 5.11.0
- AssertJ 3.26.3
- Maven Compiler plugin 3.13.0
- Maven Surefire plugin 3.5.0

It also makes sure that the tests are run on `mvn clean install` and allows all tests to be run independently in the IDE.

This is not a solution to the kata, just a fresh starting point :)